### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/nur-srijan/TimeLoop-Terminal/security/code-scanning/3](https://github.com/nur-srijan/TimeLoop-Terminal/security/code-scanning/3)

The best way to fix the problem is to add a `permissions` key with the least required permissions—usually `contents: read`—to either the entire workflow (globally, affecting all jobs) or individually to each job (such as `build` and `gui-build`). Since both jobs as shown do not require write access, and no steps attempt to modify repository contents or interact with issues, setting `permissions: contents: read` at the workflow root is simplest and satisfactory. Add this block directly under the workflow `name` (line 1), ensuring no change in functionality and completeness with principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
